### PR TITLE
use channel layers for registration events transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DB_PASSWORD=
 DB_HOST=
 DB_PORT=3306
 MYSQL_ATTR_SSL_CA=/etc/ssl/certs/ca-certificates.crt
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - Windows: `venv\Scripts\activate.ps1`
   - *nix: `source venv/bin/activate`
 - Install dependencies `python3 -m pip install -r requirements.txt`
+- Run a redis server and specify host + port in `.env`
 - Acquire osu! and discord developer credentials (client ID and client secret)
   - [Discord developer portal](https://discord.com/developers/applications) -> Create new application -> OAuth2 -> Client ID & Client Secret
     - For development, add `http://127.0.0.1:8000/auth/discord/discord_code` to the list of allowed redirect URLs

--- a/discord/routing.py
+++ b/discord/routing.py
@@ -3,5 +3,5 @@ from django.urls import path
 from . import consumers
 
 websocket_urlpatterns = [
-    path("ws/discord/", consumers.ChatConsumer.as_asgi()),
+    path("ws/discord/", consumers.DiscordRegistrationConsumer.as_asgi()),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.10'
+
+# helper compose .yml for development purposes
+services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+    restart: on-failure

--- a/fivedigitworldcup/settings.py
+++ b/fivedigitworldcup/settings.py
@@ -48,8 +48,6 @@ INSTALLED_APPS = [
     'rest_framework'
 ]
 
-ASGI_APPLICATION = 'fivedigitworldcup.asgi.application'
-
 AUTHENTICATION_BACKENDS = [
     'userauth.authentication.DiscordAndOsuAuthBackend',
     "django.contrib.auth.backends.ModelBackend"
@@ -85,7 +83,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'fivedigitworldcup.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
@@ -106,6 +103,17 @@ DATABASES = {
     }
 }
 
+ASGI_APPLICATION = 'fivedigitworldcup.asgi.application'
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [
+                (os.environ.get("REDIS_HOST", "127.0.0.1"), int(os.environ.get("REDIS_PORT", "6379"))),
+            ],
+        },
+    },
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
@@ -125,7 +133,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
@@ -136,7 +143,6 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
@@ -166,6 +172,7 @@ DISCORD_CLIENT_ID = os.environ.get("DISCORD_CLIENT_ID", None)
 DISCORD_CLIENT_SECRET = os.environ.get("DISCORD_CLIENT_SECRET", None)
 DISCORD_REDIRECT_URI = f"{OAUTH_REDIRECT_PREFIX}/auth/discord/discord_code"
 DISCORD_PSK = os.environ.get("DISCORD_PSK", "DONOTUSEINPRODUCTIONDONOTUSEINPRODUCTIONDONOTUSEINPRODUCTION")
+CHANNELS_DISCORD_WS_GROUP_NAME = "5wc_discord_signups"
 
 OSU_API_ENDPOINT = "https://osu.ppy.sh/api/v2"
 OSU_OAUTH_ENDPOINT = "https://osu.ppy.sh/oauth"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ urllib3==2.0.7
 daphne==4.0.0
 mysqlclient~=2.2.0
 python-dotenv~=1.0.0
+channels-redis~=4.1.0

--- a/userauth/authentication.py
+++ b/userauth/authentication.py
@@ -1,7 +1,12 @@
+import json
+
+from django.conf import settings
 from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.models import User
-
 from userauth.models import TournamentPlayer
+
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
 
 
 class DiscordAndOsuAuthBackend(BaseBackend):
@@ -40,6 +45,16 @@ class DiscordAndOsuAuthBackend(BaseBackend):
         except TournamentPlayer.DoesNotExist:
             tourney_player = TournamentPlayer(user=user, discord_user_id=discord_user_id, osu_user_id=osu_user_id)
             tourney_player.save()
+            channel_layer = get_channel_layer()
+            async_to_sync(channel_layer.group_send)(settings.CHANNELS_DISCORD_WS_GROUP_NAME,
+                                                    {
+                                                        "type": "registration.new",
+                                                        "message": json.dumps({
+                                                            "user_id": tourney_player.discord_user_id,
+                                                            "is_organizer": tourney_player.is_organizer,
+                                                            "action": "register"
+                                                        })
+                                                    })
         return user
 
     def get_user(self, user_id):

--- a/userauth/views.py
+++ b/userauth/views.py
@@ -45,11 +45,6 @@ class SessionDetails(viewsets.ViewSet):
                                   osu_user_data=request.session.get("osu_user_data"))
         if user is not None:
             login(request, user)
-            # noinspection PyUnresolvedReferences
-            login_signal.send("login",
-                              payload={"user_id": user.tournamentplayer.discord_user_id,
-                                       "is_organizer": user.tournamentplayer.is_organizer,
-                                       "action": "register"})
             return Response({"ok": "logged in", "user": user.username})
         return Response({"error": "failed to authenticate"}, status=status.HTTP_401_UNAUTHORIZED)
 


### PR DESCRIPTION
Replaces the existing Django signals-based approach, which does not work well across multiple workers.

This adds a dependency on Redis, but it does not store nor transports any sensitive/mission-critical data.