### PR TITLE
temp fix parse_return_page to correctly return None

### DIFF
--- a/userauth/views.py
+++ b/userauth/views.py
@@ -20,6 +20,8 @@ def parse_return_page(request):
     # TODO: add this back when frontend/backend are hosted together or add FRONTEND_BASEURL env var and check against it
     # if not return_page.startswith("/"):
     #     return_page = None
+    if not return_page:
+        return_page = None
     return return_page
 
 


### PR DESCRIPTION
After the removal of the check for redirect URLs to start with "/", [parse_return_page](https://github.com/ILW8/2024API/blob/d7bafa71116ad71d12d481791fd9c8b22a7410ad/userauth/views.py#L16) would incorrectly return an empty string instead of returning None when no redirect URL was given.

This adds a stopgap measure to fix the return value until a proper check is put back in place