### PR TITLE
Restrict team listing to admins (PSK owners) and team organizers

### DIFF
--- a/discord/views.py
+++ b/discord/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, AnonymousUser
 from django.db.models import Q
 from django.http import Http404
 from rest_framework.authentication import TokenAuthentication
@@ -28,6 +28,16 @@ class PreSharedKeyAuthentication(TokenAuthentication, BasePermission):
             raise exceptions.AuthenticationFailed(_('Invalid token.'))
 
         return None, key
+
+
+class TeamOrganizer(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if isinstance(request.user, AnonymousUser):
+            return False
+        if not request.user.tournamentplayer.is_organizer or request.user.tournamentplayer.team != obj:
+            return False
+
+        return True
 
 
 # Create your views here.

--- a/discord/views.py
+++ b/discord/views.py
@@ -13,10 +13,13 @@ from userauth.models import TournamentPlayer
 from rest_framework import serializers, viewsets
 
 
+class ReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return request.method in permissions.SAFE_METHODS
+
+
 class PreSharedKeyAuthentication(TokenAuthentication, BasePermission):
     def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
         auth = self.authenticate(request)
         return auth is not None
 
@@ -50,7 +53,7 @@ class TournamentPlayerSerializer(serializers.HyperlinkedModelSerializer):
 class TournamentPlayerViewSet(viewsets.ModelViewSet):
     serializer_class = TournamentPlayerSerializer
     queryset = TournamentPlayer.objects.all()
-    permission_classes = [PreSharedKeyAuthentication, ]
+    permission_classes = [PreSharedKeyAuthentication | ReadOnly]
 
     def retrieve(self, request, *args, **kwargs):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
+wheel~=0.42.0
+
 asgiref==3.7.2
 certifi==2023.7.22
 channels==4.0.0
 charset-normalizer==3.3.0
-Django==4.2.6
+Django~=4.2.6
 django-filter==23.3
 djangorestframework==3.14.0
 idna==3.4

--- a/teammgmt/views.py
+++ b/teammgmt/views.py
@@ -37,16 +37,12 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
     @action(methods=['get', 'PATCH'], detail=True, permission_classes=[PreSharedKeyAuthentication | TeamOrganizer])
     def members(self, request, **kwargs):
         """
-        only allow organizer of team to see team registrants and roster
+        only organizer of team and admins can see team registrants and roster
         :param request:
         :param kwargs:
         :return:
         """
         team = self.get_object()
-        # request.user is an instance of AnonymousUser if the request was authenticated and authorized using PSK
-        # I don't like this nested `if`, but it's the simplest way of doing it
-
-
         if request.method == "PATCH" and 'players' in request.data:
             players = request.data['players']
             try:

--- a/teammgmt/views.py
+++ b/teammgmt/views.py
@@ -32,7 +32,7 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
     serializer_class = TournamentTeamSerializer
     queryset = TournamentTeam.objects.all()
     http_method_names = ["get", "patch"]
-    permission_classes = [PreSharedKeyAuthentication, ]
+    permission_classes = [PreSharedKeyAuthentication]
 
     @action(methods=['get', 'PATCH'], detail=True)
     def members(self, request, **kwargs):

--- a/teammgmt/views.py
+++ b/teammgmt/views.py
@@ -3,7 +3,7 @@ from rest_framework import serializers, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from discord.views import TournamentPlayerSerializer, PreSharedKeyAuthentication, TeamOrganizer
+from discord.views import TournamentPlayerSerializer, PreSharedKeyAuthentication, TeamOrganizer, ReadOnly
 from teammgmt.models import TournamentTeam
 from userauth.models import TournamentPlayer
 
@@ -32,9 +32,9 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
     serializer_class = TournamentTeamSerializer
     queryset = TournamentTeam.objects.all()
     http_method_names = ["get", "patch"]
-    permission_classes = [PreSharedKeyAuthentication | TeamOrganizer]
+    permission_classes = [ReadOnly]
 
-    @action(methods=['get', 'PATCH'], detail=True)
+    @action(methods=['get', 'PATCH'], detail=True, permission_classes=[PreSharedKeyAuthentication | TeamOrganizer])
     def members(self, request, **kwargs):
         """
         only allow organizer of team to see team registrants and roster

--- a/teammgmt/views.py
+++ b/teammgmt/views.py
@@ -3,7 +3,7 @@ from rest_framework import serializers, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from discord.views import TournamentPlayerSerializer, PreSharedKeyAuthentication
+from discord.views import TournamentPlayerSerializer, PreSharedKeyAuthentication, TeamOrganizer
 from teammgmt.models import TournamentTeam
 from userauth.models import TournamentPlayer
 
@@ -32,7 +32,7 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
     serializer_class = TournamentTeamSerializer
     queryset = TournamentTeam.objects.all()
     http_method_names = ["get", "patch"]
-    permission_classes = [PreSharedKeyAuthentication]
+    permission_classes = [PreSharedKeyAuthentication | TeamOrganizer]
 
     @action(methods=['get', 'PATCH'], detail=True)
     def members(self, request, **kwargs):
@@ -45,10 +45,7 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
         team = self.get_object()
         # request.user is an instance of AnonymousUser if the request was authenticated and authorized using PSK
         # I don't like this nested `if`, but it's the simplest way of doing it
-        if not isinstance(request.user, AnonymousUser):
-            if not request.user.tournamentplayer.is_organizer or request.user.tournamentplayer.team != team:
-                return Response({'error': f'user is not team organizer for team {team.osu_flag}'},
-                                status=status.HTTP_403_FORBIDDEN)
+
 
         if request.method == "PATCH" and 'players' in request.data:
             players = request.data['players']


### PR DESCRIPTION
Listing of teams anonymously is still possible.

Listing team candidates and current roster requires the logged in user to be the team's organizer.