### PR TITLE
add CSRF_TRUSTED_ORIGINS & fix return status/body on logout/delete

### DIFF
--- a/fivedigitworldcup/settings.py
+++ b/fivedigitworldcup/settings.py
@@ -49,6 +49,7 @@ ALLOWED_HOSTS = ['api.vps.5wc.stagec.xyz', 'vps.5wc.stagec.xyz', '.localhost', '
 # CORS_ALLOWED_ORIGINS = ['http://vps.5wc.stagec.xyz:8080', 'https://vps.5wc.stagec.xyz:8080']
 CORS_ALLOWED_ORIGINS = [f'http://vps.5wc.stagec.xyz:{port}' for port in range(8000, 9000)]
 CORS_ALLOW_CREDENTIALS = True
+CSRF_TRUSTED_ORIGINS = [f"http://*.vps.5wc.stagec.xyz:{port}" for port in range(8000, 9000)]
 
 SESSION_COOKIE_DOMAIN = ".vps.5wc.stagec.xyz"
 

--- a/fivedigitworldcup/settings.py
+++ b/fivedigitworldcup/settings.py
@@ -47,9 +47,11 @@ DEBUG = strtobool(os.environ.get("DJANGO_DEBUG", "false"))
 ALLOWED_HOSTS = ['api.vps.5wc.stagec.xyz', 'vps.5wc.stagec.xyz', '.localhost', '127.0.0.1', '[::1]']
 # CORS_ALLOW_ALL_ORIGINS = True
 # CORS_ALLOWED_ORIGINS = ['http://vps.5wc.stagec.xyz:8080', 'https://vps.5wc.stagec.xyz:8080']
-CORS_ALLOWED_ORIGINS = [f'http://vps.5wc.stagec.xyz:{port}' for port in range(8000, 9000)]
+CORS_ALLOWED_ORIGINS = ([f'http://vps.5wc.stagec.xyz:{port}' for port in range(8000, 9000)]
+                        + ["http://vps.5wc.stagec.xyz:2082"])
 CORS_ALLOW_CREDENTIALS = True
-CSRF_TRUSTED_ORIGINS = [f"http://*.vps.5wc.stagec.xyz:{port}" for port in range(8000, 9000)]
+CSRF_TRUSTED_ORIGINS = ([f"http://*.vps.5wc.stagec.xyz:{port}" for port in range(8000, 9000)]
+                        + ["http://*.vps.5wc.stagec.xyz:2082"])
 
 SESSION_COOKIE_DOMAIN = ".vps.5wc.stagec.xyz"
 

--- a/fivedigitworldcup/settings.py
+++ b/fivedigitworldcup/settings.py
@@ -52,6 +52,7 @@ CORS_ALLOWED_ORIGINS = ([f'http://vps.5wc.stagec.xyz:{port}' for port in range(8
 CORS_ALLOW_CREDENTIALS = True
 CSRF_TRUSTED_ORIGINS = ([f"http://*.vps.5wc.stagec.xyz:{port}" for port in range(8000, 9000)]
                         + ["http://*.vps.5wc.stagec.xyz:2082"])
+CSRF_COOKIE_DOMAIN = ".vps.5wc.stagec.xyz"
 
 SESSION_COOKIE_DOMAIN = ".vps.5wc.stagec.xyz"
 

--- a/userauth/views.py
+++ b/userauth/views.py
@@ -43,7 +43,7 @@ class SessionDetails(viewsets.ViewSet):
         if request.session.get("osu_user_data") is not None:
             del request.session["osu_user_data"]
         logout(request)
-        return Response({"ok": "logged out"}, status=status.HTTP_204_NO_CONTENT)
+        return Response({"ok": "logged out"}, status=status.HTTP_200_OK)
 
     @action(methods=['get', 'post'], detail=False)
     def login(self, request):
@@ -66,7 +66,7 @@ class SessionDetails(viewsets.ViewSet):
         user = request.user
         logout(request)
         user.delete()
-        return Response({"ok": "account deleted"}, status=status.HTTP_204_NO_CONTENT)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
 
 
 class OauthWithRedirect:


### PR DESCRIPTION
Starting with Django 4.0, CSRF middleware checks the request ORIGIN header. Without CSRF_TRUSTED_ORIGINS, unsafe HTTP methods will be blocked if ORIGIN is listed in CSRF_TRUSTED_ORIGINS.
Strictly speaking, we should really change CORS_ALLOWED_ORIGINS and CSRF_TRUSTED_ORIGINS but that can wait until deployment...


Also fixes the session delete and logout endpoint trying to return a response body with status code 204; when returning HTTP_204, there should be no response body.