### PR TITLE
add management and filtering of staff registrants

### DIFF
--- a/teammgmt/views.py
+++ b/teammgmt/views.py
@@ -7,10 +7,10 @@ from rest_framework import serializers, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
 from discord.views import TournamentPlayerSerializer, PreSharedKeyAuthentication, TeamOrganizer, ReadOnly
+from userauth.authentication import IsSuperUser
 from teammgmt.models import TournamentTeam
 from userauth.models import TournamentPlayer
 
@@ -83,7 +83,7 @@ class TournamentTeamViewSet(viewsets.ModelViewSet):
 
     @action(methods=['get', 'PATCH'],
             detail=True,
-            permission_classes=[PreSharedKeyAuthentication | TeamOrganizer | IsAdminUser])
+            permission_classes=[PreSharedKeyAuthentication | TeamOrganizer | IsSuperUser])
     def members(self, request, **kwargs):
         """
         only organizer of team and admins can see team registrants and roster

--- a/userauth/authentication.py
+++ b/userauth/authentication.py
@@ -8,6 +8,7 @@ from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import BasePermission
 
 from teammgmt.models import TournamentTeam
 from userauth.models import TournamentPlayer, TournamentPlayerBadge
@@ -201,3 +202,12 @@ class DiscordAndOsuAuthBackend(BaseBackend):
             return User.objects.get(pk=user_id)
         except User.DoesNotExist:
             return None
+
+
+class IsSuperUser(BasePermission):
+    """
+    Allows access only to superusers.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_superuser)


### PR DESCRIPTION
send PATCH or POST to `/registrants/<discord_user_id>/?key=discord` with body
```json
{
    "is_staff": true
}
```

requires having a session logged in as superuser or include PSK in auth header